### PR TITLE
[TWM-153] Remove press sync from entrypoint.

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.k8s.temple.edu/library/ruby:2.7-alpine as builder
+FROM harbor.k8s.temple.edu/library/ruby:2.7-alpine
 
 WORKDIR /app
 

--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -2,10 +2,5 @@
 set -e
 
 rails db:migrate 2>/dev/null || rails db:setup
-
-if [ "$DB_SYNC" != "no" ]; then
-  rails sync:pressworks:all[press.xml]
-fi
-
 rm -f /app/tmp/pids/server.pid
 exec "$@"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 `bundle exec rails sync:pressworks:all[press.xml]`
 
 #### For the docker instance:
-* By default the database sync is not run locally. Use `make run DB_SYNC=yes` to run it.
+* By default the database sync is not run locally. Use `make load-data` to run it.
 
 ### Start the Application using Docker as an alternative
 


### PR DESCRIPTION
We are moving the press db sync step to a k8 cronjob (sidecar solution
is more complicated in this instance).

This commit removes the press db sync fro the entrypoint and adds
a pressdb sync for local docker environment via `make db-sync`

This also add a little bit of cleanup for the Makefile to duplication
errors.