### PR TITLE
Store all subject objects as JSON blobs in the book table

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -31,4 +31,8 @@ class Book < ApplicationRecord
       self.sort_title = self.title
     end
   end
+
+  def subjects_as_tuples
+    [JSON.parse(self.subjects)["subject"]].flatten.map { |h| [h["subject_title"], h["subject_id"]] }
+  end
 end

--- a/app/services/sync_service/books.rb
+++ b/app/services/sync_service/books.rb
@@ -33,8 +33,7 @@ class SyncService::Books
 
   def read_books
     @booksDoc.xpath("//record").map do |node|
-      node_xml = Nokogiri.XML(node.to_xml)
-      Hash.from_xml(node_xml.to_xml)
+      Hash.from_xml(node.serialize(encoding: "UTF-8"))
     end
   end
 
@@ -71,7 +70,7 @@ class SyncService::Books
       "series_id"           => record["record"].fetch("series/series_id", nil),
       "binding"             => record["record"].fetch("bindings", nil),
       "description"         => record["record"].fetch("description", nil),
-      "subjects"            => record["record"].fetch("subjects", "{\"subject\"=>{\"subject_id\"=>nil, \"subject_title\"=>nil}}"),
+      "subjects"            => JSON.dump(record["record"].fetch("subjects", { "subject" => { "subject_id" => nil, "subject_title" => nil } })),
       "contents"            => record["record"].fetch("contents", nil),
       "catalog_id"          => record["record"].fetch("catalog", nil)
     }

--- a/app/views/fields/subjects_select_field/_form.html.erb
+++ b/app/views/fields/subjects_select_field/_form.html.erb
@@ -1,20 +1,12 @@
 <%
-  subject_list = eval field.resource.subjects
-  subjects = []
-  
-  subject_list["subject"].each do |subject|
-    subjects.push [subject['subject_title'], subject['subject_id']] 
-  end if subject_list["subject"].kind_of?(Array)
-
-  subjects.push [subject_list["subject"]["subject_title"], subject_list["subject"]["subject_id"]] if subject_list["subject"].kind_of?(Hash)
-
+  subjects = field.resource.subjects_as_tuples
 %>
 <div class="field-unit__label">
   <%= f.label field.attribute, for: "#{f.object_name}_#{field.attribute}" %>
 </div>
 <div class="field-unit__field">
-  <%= select_tag "#{f.object_name}[#{field.attribute}]", 
-                  options_for_select(subjects, {selected: field.data.presence}), 
-                  include_blank: "(none)"
-                %>
+  <%= select_tag "#{f.object_name}[#{field.attribute}]",
+		  options_for_select(subjects, {selected: field.data.presence}),
+		  include_blank: "(none)"
+		%>
 </div>

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 RSpec.describe Book, type: :model do
 
+  it "can list subjects as tuples (arrays) of (title , id)" do
+    book = described_class.new
+    book.assign_attributes("subjects" => JSON.dump({ "subject" => { "subject_id" => 1, "subject_title" => "foo" } }))
+    expect(book.subjects_as_tuples).to eq [["foo", 1]]
+  end
+
+
   context "Required Fields" do
     required_fields = [
       "author_byline",

--- a/spec/services/xml_books_spec.rb
+++ b/spec/services/xml_books_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe SyncService::Books, type: :service do
       end
 
       it "maps subjects to subjects field" do
-        expect(subject["subjects"]).to match(@books.first["record"]["subjects"])
+        expect(JSON.parse(subject["subjects"])).to eq(@books.first["record"]["subjects"])
       end
 
       it "maps contents to contents field" do
@@ -92,7 +92,6 @@ RSpec.describe SyncService::Books, type: :service do
       it "maps catalog_id to catalog_id field" do
         expect(subject["catalog_id"]).to match(@books.first["record"]["catalog"])
       end
-
     end
   end
 


### PR DESCRIPTION
I think this will normalize the book.subject data as JSON blobs (will require a clean DB). Ideally the JSON parsing and unparsing should happen as some before_save hooks. 