### PR TITLE
Revert "Bump selenium-webdriver from 4.2.1 to 4.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
       sprockets-rails
       tilt
     selectize-rails (0.12.6)
-    selenium-webdriver (4.3.0)
+    selenium-webdriver (4.2.1)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)


### PR DESCRIPTION
Reverts tulibraries/Press-6#409

NoMethodError: undefined method `driver_path=' for Selenium::WebDriver::Chrome:Module