### PR TITLE
TWM-384: Make tupress-prod file system read only.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,5 +84,5 @@ prod_deploy:
     - tags
   script:
     - helm repo add tulibraries https://$HARBOR/chartrepo/tulibraries
-    - helm pull tulibraries/tupress --version 0.2.1 --untar
+    - helm pull tulibraries/tupress --version 0.3.0 --untar
     - helm upgrade tupress ./tupress --values ./tupress/values-prod.yaml --history-max 5 --namespace tupress-prod --set image.repository=$IMAGE:$CI_COMMIT_TAG


### PR DESCRIPTION
Update the prod deploy for tupress with new version that updates that
makes the deployment filesystem read only by default.

Depends on:
- [ ] https://git.temple.edu/tulibraries/charts/-/merge_requests/54