### PR TITLE
Use OCI object for helm chart

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,8 @@ include:
 
 variables:
   IMAGE: "tulibraries/tupress"
+  HARBOR: "harbor.k8s.temple.edu"
+  HELM_EXPERIMENTAL_OCI: "1"
 
 .export_variables: &export_variables
   - source .env
@@ -34,11 +36,11 @@ lint:
 build:
   stage: build
   extends: .build_image
-  image: harbor.k8s.temple.edu/gitlab-ci/docker:20
+  image: $HARBOR/gitlab-ci/docker:20
   variables:
     DF: ".docker/app/Dockerfile --build-arg RAILS_MASTER_KEY=$MASTER_KEY --no-cache"
   services:
-    - name: harbor.k8s.temple.edu/gitlab-ci/docker:20-dind
+    - name: $HARBOR/gitlab-ci/docker:20-dind
       command: ["--tls=false"]
   except:
     - tags
@@ -60,7 +62,7 @@ tag:
 
 qa_deploy:
   variables:
-    IMAGE: harbor.k8s.temple.edu/tulibraries/tupress
+    IMAGE: $HARBOR/tulibraries/tupress
     RANCHER: rancher-np
     CLUSTER: dev-library
   stage: deploy
@@ -69,9 +71,7 @@ qa_deploy:
     - main
   script:
     - *export_variables
-    - helm repo add tulibraries https://$HARBOR/chartrepo/tulibraries
-    - helm pull tulibraries/tupress --untar
-    - helm upgrade tupress ./tupress --history-max=5 --namespace=tupress-qa --set image.repository=$IMAGE:$VERSION
+    - helm upgrade tupress oci://$HARBOR/tulibraries/tupress --version "0.3.*" --history-max=5 --namespace=tupress-qa 
 
 prod_deploy:
   variables:
@@ -83,6 +83,4 @@ prod_deploy:
   only:
     - tags
   script:
-    - helm repo add tulibraries https://$HARBOR/chartrepo/tulibraries
-    - helm pull tulibraries/tupress --version 0.3.0 --untar
-    - helm upgrade tupress ./tupress --values ./tupress/values-prod.yaml --history-max 5 --namespace tupress-prod --set image.repository=$IMAGE:$CI_COMMIT_TAG
+    - helm upgrade tupress oci://$HARBOR/tulibraries/tupress --version "0.3.0" --history-max=5 --namespace=tupress-prod 


### PR DESCRIPTION
The chart museum in harbor is deprecated.  This updates our deployments to get the helm charts from an OCI object instead of the chart museum that we were previously using.  I don't think it is necessary to pull and upgrade, but can add that command back in if this doesn't work as expected.