### PR TITLE
comment out ssl directives in config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
@@ -102,5 +102,5 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  Rails.application.routes.default_url_options[:protocol] = "https"
+  # Rails.application.routes.default_url_options[:protocol] = "https"
 end


### PR DESCRIPTION
This is to avoid the Puma error of not being configured for ssl.

We will try to get ITS to handle the security of the cookies raised in the review.