### PR TITLE
Revise production deploy process to use regular versioning and tag image with 'prod'.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,6 +74,22 @@ qa_deploy:
     -  helm pull oci://$HARBOR/tulibraries/tupress-charts/tupress --version "0.3.*" --untar
     - helm upgrade tupress oci://$HARBOR/tulibraries/tupress-charts/tupress --version "0.3.*" --history-max=5 --namespace=tupress-qa --values tupress/values.yaml --set image.repository=$IMAGE:$VERSION
 
+tag_prod:
+  stage: tag
+  extends: .tag_image
+  variables:
+    TAG: prod
+  only:
+    - tags
+
+tag_release:
+  stage: tag
+  extends: .tag_image
+  variables:
+    TAG: $CI_COMMIT_TAG
+  only:
+    - tags
+
 prod_deploy:
   variables:
     IMAGE: harbor.k8s.temple.edu/tulibraries/tupress

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ We defined a Makefile with many useful commands for local development. These com
 * Deploys to https://tupress-qa.k8s.temple.edu
 
 ### Production
-* To deploy the app to the prod cluster, add a new release via gitlab. The release image will be tagged with "prod" and with the release tag you use in the release.
+* In order to deploy to production, create a release in GitLab. The release tag normally used for releases should continue to be added manually during the release process, e.g. “1.3.3”. Gitlab will then automatically tag the release image with both a “prod” tag and a release tag that references the git tag (e.g. 1.3.3). The newly tagged image will then be deployed to the production environment.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ We defined a Makefile with many useful commands for local development. These com
 ## Deployment
 ### QA
 * Deploys to https://tupress-qa.k8s.temple.edu
+
+### Production
+* To deploy the app to the prod cluster, add a new release via gitlab. The release image will be tagged with "prod" and with the release tag you use in the release.


### PR DESCRIPTION
Makes deploying to production easier by removing the dependency between the tag
used for the release and the tag used for the image on Harbor.