### PR TITLE
Fix linting error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,5 +139,8 @@ Rails/OutputSafety:
 Rails/HttpPositionalArguments:
   Enabled: false
 
+Rails/FindEach:
+  Enabled: false
+
 Rails/LexicallyScopedActionFilter:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
-    rubocop-rails (2.20.2)
+    rubocop-rails (2.21.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)


### PR DESCRIPTION
The latest rubocop-rails update (2.21.0) had a linting error. 
This sets Rails/FindEach to not be enabled for now.