### PR TITLE
TWM-494: Help speed up pages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,4 +103,4 @@ jobs:
             sudo mv trivy /usr/local/bin
       - run:
           name: Scan the local image with trivy
-          command: trivy image --exit-code 1 --severity CRITICAL --no-progress trivy-ci-test:${CIRCLE_SHA1}
+          command: trivy image --exit-code 1 --severity CRITICAL --no-progress --scanners vuln trivy-ci-test:${CIRCLE_SHA1}

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ load-data:
 scan:
 	@if [ $(CLEAR_CACHES) == yes ]; \
 		then \
-			trivy image --scanners vuln  -c $(HARBOR)/$(IMAGE):$(VERSION); \
+			trivy image --security-checks vuln  -c $(HARBOR)/$(IMAGE):$(VERSION); \
 		fi
 	@if [ $(CI) == false ]; \
 		then \
-		  trivy image --scanners vuln $(HARBOR)/$(IMAGE):$(VERSION); \
+		  trivy image --security-checks vuln $(HARBOR)/$(IMAGE):$(VERSION); \
 		fi
 
 deploy: scan lint

--- a/app/models/concerns/imageable.rb
+++ b/app/models/concerns/imageable.rb
@@ -16,22 +16,27 @@ module Imageable
   end
 
   def custom_image(image_field, width, height)
-    send(image_field.to_sym).blob.analyze
-    if (send(image_field.to_sym).blob.metadata[:width] != width) || (send(image_field.to_sym).blob.metadata[:height] != height)
-      if send(image_field.to_sym).blob.metadata[:width] > send(image_field.to_sym).blob.metadata[:height]
-        send(image_field.to_sym).variant(format: :png,
-                                         background: :transparent,
-                                         gravity: "North",
-                                         resize_to_fit: [width, height]).processed
+    image = send(image_field.to_sym)
+    image.analyze unless image.analyzed
+
+    image_width = image.metadata[:width]
+    image_height = image.metadata[:height]
+
+    if (image_width != width) || (image_height != height)
+      if image_width > image_height
+        image.variant(format: :png,
+                      background: :transparent,
+                      gravity: "North",
+                      resize_to_fit: [width, height]).processed
       else
-        send(image_field.to_sym).variant(format: :png,
-                                         background: :transparent,
-                                         gravity: :center,
-                                         resize_and_pad: [width,
-                                                          height]).processed
+        image.variant(format: :png,
+                      background: :transparent,
+                      gravity: :center,
+                      resize_and_pad: [width,
+                                       height]).processed
       end
     else
-      send(image_field.to_sym)
+      image
     end
   end
 end


### PR DESCRIPTION
Recently the TUPress front page has taken longer and longer to download. I have determined that this is being caused because we are downloading images from s3 to check for width and height even when the width and height are already present.  This change updates the code to check that image has not been "analzyed" before "analyzing" it which makes the image get downloaded locally.

The s3 downloads are cumulative and vary in how long they they from 10 to 100s to 1000s of milliseconds each.