### PR TITLE
Remove required from book_title (temporary fix)

### DIFF
--- a/app/views/forms/review-copy/_request-info.html.erb
+++ b/app/views/forms/review-copy/_request-info.html.erb
@@ -4,7 +4,7 @@
         item_wrapper_class: "form-check inline mt-2 mb-3",
         required: true %>
         
-<%= f.input :book_title, required: true %>
+<%= f.input :book_title %>
 
 <%= f.input :comments, as: :text, 
         input_html: { cols: 60, rows: 5 },


### PR DESCRIPTION
For some reason requiring the book_title field is preventing the form submission from working.  I'm going to remove this as a temporary workaround until Chris comes back and can implement a better, permanent solution.