### PR TITLE
Twm 513 review copy form not submitting

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import { DirectUpload } from "@rails/activestorage"
-import "jquery"
 import "sifter"
 import "microplugin"
 import "./controllers"
@@ -9,5 +8,6 @@ import * as bootstrap from "bootstrap"
 import Trix from "trix";
 import "@rails/actiontext"
 import "selectize"
+import "./src/jquery"
 import "./src/jumble"
 import "./src/administrate-trix"

--- a/app/javascript/src/jquery.js
+++ b/app/javascript/src/jquery.js
@@ -1,0 +1,3 @@
+import jquery from "jquery"
+window.jQuery = jquery
+window.$ = jquery

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -71,14 +71,6 @@
             </fieldset>
           </div>
         </div>
-
-        <div class="row d-none">
-          <div class="col">
-            <fieldset class="bordered">
-              <%= render "forms/#{@type}/request-info", f: f %>
-            </fieldset>
-          </div>
-        </div>
       <% end %>
 
         <div class="row mt-4">


### PR DESCRIPTION
Request fields were duplicated in the code, and the duplicates were marked as hidden. This caused one Book Title field to be empty (the hidden one) while the other was populated. We use the HTML5 browser implementation for required fields. When required, the field must be populated. The browser implementation found the hidden field empty but could not put focus on that field to display the error message because it was hidden. This resulted in a form that would not submit with no apparent reason why. This is a leftover attempt at spam remediation which should have been cleaned up. The hidden fields are unnecessary now that the anti-spam we're using (the :survey field as a honeypot) has changed. 

Debugging also showed errors in the console where the $ sign for Jquery was not being recognized. Changed the method for adding Jquery back to a previous state, using the .src/ folder to import and define the dollar sign. 