### PR TITLE
TWM-517 Fix Honeybadger ActiveRecord::StatementInvalid

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -14,7 +14,8 @@ class Subject < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
-      Subject.where("title ~* ?", "(^|\\W)#{q}(\\W|$)").sort
+      escaped_q = Regexp.escape(q)
+      Subject.where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)").sort
     end
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -9,4 +9,26 @@ RSpec.describe Subject, type: :model do
 
   it_behaves_like "attachable"
   it_behaves_like "detachable"
+
+  describe ".search(q)" do
+    let!(:subject1) { Subject.create!(title: "Ruby on Rails Guide") }
+    let!(:subject2) { Subject.create!(title: "PostgreSQL for Beginners") }
+    let!(:subject3) { Subject.create!(title: "C++ Programming") }
+
+    it "returns subjects that match the results" do
+      results = Subject.search("Rails")
+      expect(results).to include(subject1)
+      expect(results).not_to include(subject2)
+    end
+
+    it "is case insensitive" do
+      results = Subject.search("ruby")
+      expect(results).to include(subject1)
+    end
+
+    it "escapes special regex characters" do
+      results = Subject.search("C++")
+      expect(results).to include(subject3)
+    end
+  end
 end


### PR DESCRIPTION
The way the code was written, it did not escape special characters.  So anytime special characters were used, it threw an error.  This fixes the error and adds tests to the method.