### PR TITLE
TWM-518 Ignore this error in Honeybadger

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,0 +1,4 @@
+---
+exceptions:
+  ignore:
+    - "undefined method `order' for nil"


### PR DESCRIPTION
It looks like this error is always caused by a bot going to a URL that doesn't exist.  Let's just add it to an exceptions ignore list so that it doesn't throw an error in Honeybadger.