### PR TITLE
Accessibility 042025

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add -U --no-cache \
       gcompat=1.1.0-r4 \
       imagemagick=7.1.1.41-r0 \
       libxslt=1.1.42-r2 \
-      postgresql16-client=16.8-r0 \
+      postgresql16-client=16.9-r0 \
       shared-mime-info=2.4-r2 \
       ssl_client=1.37.0-r12 \
       tzdata=2025b-r0 && \

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -36,7 +36,7 @@ RUN apk add -U --no-cache \
       libjpeg-turbo-dev=3.0.4-r0 \
       libxslt-dev=1.1.42-r2 \
       libxml2-dev=2.13.4-r5 \
-      postgresql16-dev=16.8-r0 \
+      postgresql16-dev=16.9-r0 \
       nodejs=22.13.1-r0 \
       yarn=1.22.22-r1 && \
     if [ "${RAILS_ENV}" = "production" ]; then bundle config set --local without "development test"; fi && \

--- a/app/dashboards/brochure_dashboard.rb
+++ b/app/dashboards/brochure_dashboard.rb
@@ -13,6 +13,7 @@ class BrochureDashboard < Administrate::BaseDashboard
     id: Field::Number,
     title: Field::String,
     image: ImageField,
+    image_alt_text: Field::String,
     pdf: FileField,
     promoted_to_homepage: Field::Boolean,
     created_at: Field::DateTime,
@@ -44,6 +45,7 @@ class BrochureDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     title
     image
+    image_alt_text
     pdf
     promoted_to_homepage
   ].freeze

--- a/app/dashboards/catalog_dashboard.rb
+++ b/app/dashboards/catalog_dashboard.rb
@@ -19,6 +19,7 @@ class CatalogDashboard < Administrate::BaseDashboard
     suppress: Field::Boolean,
     pdf: FileField,
     image: ImageField,
+    image_alt_text: Field::String,
     brochures: Field::HasMany.with_options(
       order: "sort_title"
     ),
@@ -54,6 +55,7 @@ class CatalogDashboard < Administrate::BaseDashboard
     year
     pdf
     image
+    image_alt_text
     brochures
     suppress
   ].freeze

--- a/app/dashboards/series_dashboard.rb
+++ b/app/dashboards/series_dashboard.rb
@@ -18,6 +18,7 @@ class SeriesDashboard < Administrate::BaseDashboard
     description: TrixField,
     founder: Field::String,
     image: FileField,
+    image_alt_text: Field::String,
     unpublish: Field::Boolean,
     image_link: Field::String,
     created_at: Field::DateTime,
@@ -54,6 +55,7 @@ class SeriesDashboard < Administrate::BaseDashboard
     code
     slug
     image
+    image_alt_text
     image_link
     editors
     founder

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def aria_hidden(model)
+    if model.class.to_s == "Book"
+      alt_text = model.cover_alt_text
+    else
+      alt_text = model.image_alt_text
+    end
+    alt_text.present? ? false : true
+  end
+
   def search_glass
     image_path("mag.png")
   end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module BooksHelper
-  def aria_hidden(book)
-    book.cover_alt_text.present? ? false : true
-  end
-
   def book_format(format)
     case format
     when "PB"

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module BooksHelper
+  def aria_hidden(book)
+    book.cover_alt_text.present? ? false : true
+  end
+
   def book_format(format)
     case format
     when "PB"

--- a/app/helpers/webpages_helper.rb
+++ b/app/helpers/webpages_helper.rb
@@ -3,9 +3,9 @@
 module WebpagesHelper
   def display_image(model, homepage = false)
     if model.image.attached?
-      (image_tag model.image, loading: "lazy")
+      (image_tag model.image, loading: "lazy", "aria-hidden": aria_hidden(model))
     else
-      (image_tag "default-book-cover-index.png", loading: "lazy")
+      (image_tag "default-book-cover-index.png", loading: "lazy", "aria-hidden": true)
     end
   end
 

--- a/app/views/books/_books.html.erb
+++ b/app/views/books/_books.html.erb
@@ -1,13 +1,9 @@
   <% @books.each do |book| %>  
     <div class="row pb-lg-4 mt-lg-4 mb-lg-4 px-3 book-listing">
       <div class="col-12 col-md-4 col-lg-3 py-3 text-center">
-        <%= link_to book_path(book), "aria-hidden": aria_hidden do %>
+        <%= link_to book_path(book), "aria-hidden": aria_hidden(book) do %>
           <% if book.cover_image.attached? %>
-            <% if book.cover_alt_text.present? %>
-              <%= image_tag book.index_image("cover_image"), class: "cover-image", alt: book.cover_alt_text %>
-            <% else %>
-              <%= image_tag book.index_image("cover_image"), class: "cover-image", alt: nil, "aria-hidden": true %>
-            <% end %>
+            <%= image_tag book.index_image("cover_image"), class: "cover-image", "aria-hidden": aria_hidden(book), alt: book.cover_alt_text %>
           <% else %>
             <%= image_tag "default-book-cover-index.png", alt: nil, "aria-hidden": true  %>
           <% end %>

--- a/app/views/books/_books.html.erb
+++ b/app/views/books/_books.html.erb
@@ -1,11 +1,15 @@
   <% @books.each do |book| %>  
     <div class="row pb-lg-4 mt-lg-4 mb-lg-4 px-3 book-listing">
       <div class="col-12 col-md-4 col-lg-3 py-3 text-center">
-        <%= link_to book_path(book) do %>
+        <%= link_to book_path(book), "aria-hidden": aria_hidden do %>
           <% if book.cover_image.attached? %>
-            <%= image_tag book.index_image("cover_image"), class: "cover-image" %>
+            <% if book.cover_alt_text.present? %>
+              <%= image_tag book.index_image("cover_image"), class: "cover-image", alt: book.cover_alt_text %>
+            <% else %>
+              <%= image_tag book.index_image("cover_image"), class: "cover-image", alt: nil, "aria-hidden": true %>
+            <% end %>
           <% else %>
-            <%= image_tag "default-book-cover-index.png"  %>
+            <%= image_tag "default-book-cover-index.png", alt: nil, "aria-hidden": true  %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/books/_cover_image.html.erb
+++ b/app/views/books/_cover_image.html.erb
@@ -5,11 +5,7 @@
 <% end if current_user %>
 
 <% if book.cover_image.attached? %>
-  <% if @book.cover_alt_text.present? %>
-    <%= image_tag book.show_image("cover_image"), class: "cover-image", alt: @book.cover_alt_text %>
-  <% else %>
-    <%= image_tag book.show_image("cover_image"), class: "cover-image" %>
-  <% end %>
+  <%= image_tag book.show_image("cover_image"), class: "cover-image", "aria-hidden": aria_hidden(book), alt: @book.cover_alt_text %>
 <% else %>
-  <%= image_tag "default-book-cover-show.png", class: "default-show-cover cover-image" %>
+  <%= image_tag "default-book-cover-show.png", class: "default-show-cover cover-image", "aria-hidden": true %>
 <% end unless current_user %>

--- a/app/views/catalogs/_books.html.erb
+++ b/app/views/catalogs/_books.html.erb
@@ -1,11 +1,11 @@
   <% @books.each do |book| %>  
     <div class="row pb-lg-4 mt-lg-4 mb-lg-4 px-3 book-listing">
       <div class="col-12 col-md-4 col-lg-3 py-3 text-center">
-        <%= link_to book_path(book) do %>
+        <%= link_to book_path(book), "aria-hidden": aria_hidden(book) do %>
           <% if book.cover_image.attached? %>
-            <%= image_tag book.index_image("cover_image"), class: "cover-image" %>
+            <%= image_tag book.index_image("cover_image"), class: "cover-image", "aria-hidden": aria_hidden(book) %>
           <% else %>
-            <%= image_tag "default-book-cover-index.png"  %>
+            <%= image_tag "default-book-cover-index.png", "aria-hidden": true  %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -14,7 +14,7 @@
   </div>
   <% if @series.image.attached? %>
   <div class="col-3">
-    <%= link_to (image_tag @series.custom_image("image", 270, 220)), @series.image_link if @series.image.attached? %>
+    <%= link_to (image_tag @series.custom_image("image", 270, 220)), @series.image_link, {"aria-hidden": aria_hidden(@series), alt: @series.image_alt_text} if @series.image.attached? %>
     <%= image_tag @series.custom_image("image", 270, 220) unless @series.image.attached? %>
   </div>
   <% end %>

--- a/app/views/webpages/search/_book_results.html.erb
+++ b/app/views/webpages/search/_book_results.html.erb
@@ -1,7 +1,7 @@
 <% @books.each do |book| %>
 <div class="row book-row mx-1 bg-white p-4 w-100" style="border-bottom: solid #ccc 1px">
   <div class="media">
-    <%= link_to image_tag(book.thumb_image("cover_image"), class: 'd-flex mr-3'), book_path(book) if book.cover_image.attached? %>
+    <%= link_to image_tag(book.thumb_image("cover_image"), class: 'd-flex mr-3'), book_path(book), "aria-hidden": aria_hidden(book) if book.cover_image.attached? %>
   </div>
   <div class="media-body">
     <%= link_to book.title.html_safe, book_path(book), class: "book" %>

--- a/db/migrate/20250512191355_add_alt_text_to_series_images.rb
+++ b/db/migrate/20250512191355_add_alt_text_to_series_images.rb
@@ -1,0 +1,8 @@
+class AddAltTextToSeriesImages < ActiveRecord::Migration[7.2]
+  def up
+    add_column :series, :image_alt_text, :string
+  end
+  def down
+    remove_column :series, :image_alt_text
+  end
+end

--- a/db/migrate/20250512191355_add_alt_text_to_series_images.rb
+++ b/db/migrate/20250512191355_add_alt_text_to_series_images.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAltTextToSeriesImages < ActiveRecord::Migration[7.2]
   def up
     add_column :series, :image_alt_text, :string

--- a/db/migrate/20250512200351_add_alt_text_to_catalog_images.rb
+++ b/db/migrate/20250512200351_add_alt_text_to_catalog_images.rb
@@ -1,0 +1,8 @@
+class AddAltTextToCatalogImages < ActiveRecord::Migration[7.2]
+  def up
+    add_column :catalogs, :image_alt_text, :string
+  end
+  def down
+    remove_column :catalogs, :image_alt_text
+  end
+end

--- a/db/migrate/20250512200351_add_alt_text_to_catalog_images.rb
+++ b/db/migrate/20250512200351_add_alt_text_to_catalog_images.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAltTextToCatalogImages < ActiveRecord::Migration[7.2]
   def up
     add_column :catalogs, :image_alt_text, :string

--- a/db/migrate/20250513124017_add_alt_text_to_brochure_images.rb
+++ b/db/migrate/20250513124017_add_alt_text_to_brochure_images.rb
@@ -1,0 +1,8 @@
+class AddAltTextToBrochureImages < ActiveRecord::Migration[7.2]
+  def up
+    add_column :brochures, :image_alt_text, :string
+  end
+  def down
+    remove_column :brochures, :image_alt_text
+  end
+end

--- a/db/migrate/20250513124017_add_alt_text_to_brochure_images.rb
+++ b/db/migrate/20250513124017_add_alt_text_to_brochure_images.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAltTextToBrochureImages < ActiveRecord::Migration[7.2]
   def up
     add_column :brochures, :image_alt_text, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_27_194949) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_191355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -369,6 +369,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_27_194949) do
     t.bigint "book_id"
     t.string "slug", limit: 255
     t.boolean "unpublish", default: false
+    t.string "image_alt_text"
     t.index ["book_id"], name: "idx_19316_index_series_on_book_id"
     t.index ["slug"], name: "idx_19316_index_series_on_slug", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_12_191355) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_13_124017) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -181,6 +181,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_12_191355) do
     t.bigint "catalog_id"
     t.bigint "subject_id"
     t.string "slug", limit: 255
+    t.string "image_alt_text"
     t.index ["catalog_id"], name: "idx_19144_index_brochures_on_catalog_id"
     t.index ["slug"], name: "idx_19144_index_brochures_on_slug", unique: true
     t.index ["subject_id"], name: "idx_19144_index_brochures_on_subject_id"
@@ -204,6 +205,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_12_191355) do
     t.timestamptz "updated_at", null: false
     t.boolean "suppress", default: true
     t.string "slug", limit: 255
+    t.string "image_alt_text"
     t.index ["slug"], name: "idx_19153_index_catalogs_on_slug", unique: true
   end
 

--- a/spec/helpers/books_helper_spec.rb
+++ b/spec/helpers/books_helper_spec.rb
@@ -57,5 +57,17 @@ RSpec.describe BooksHelper, type: :helper do
         expect(helper.order_button(bad_status)).to eq(%())
       end
     end
+
+    describe "aria_hidden" do
+      it "returns false if cover_alt_text is present" do
+        book_with_cover.cover_alt_text = "This is an alt text"
+        expect(helper.aria_hidden(book_with_cover)).to be false
+      end
+
+      it "returns true if cover_alt_text is not present" do
+        book_with_cover.cover_alt_text = nil
+        expect(helper.aria_hidden(book_with_cover)).to be true
+      end
+    end
   end
 end

--- a/spec/helpers/webpages_helper_spec.rb
+++ b/spec/helpers/webpages_helper_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe WebpagesHelper, type: :helper do
   let(:brochure) { FactoryBot.create(:brochure) }
+  let(:brochure_with_alt_text) { FactoryBot.create(:brochure, image_alt_text: "this is alt text") }
   let(:no_image) { FactoryBot.create(:brochure, :without_image) }
   let(:book_no_image) { FactoryBot.create(:book) }
   let(:book) { FactoryBot.create(:book, :with_cover_image) }
@@ -13,7 +14,8 @@ RSpec.describe WebpagesHelper, type: :helper do
 
   describe "display images" do
     it "returns image from model" do
-      expect(helper.display_image(brochure)).to eq(image_tag(brochure.image, loading: "lazy"))
+      expect(helper.display_image(brochure)).to eq(image_tag(brochure.image, loading: "lazy", "aria-hidden": "true"))
+      expect(helper.display_image(brochure_with_alt_text)).to eq(image_tag(brochure_with_alt_text.image, loading: "lazy", "aria-hidden": "false"))
     end
     it "returns default image when model image nil - homepage" do
       expect(helper.display_image(no_image, true)).to include("default-book-cover-index")


### PR DESCRIPTION
This phase of the accessibility remediation extends the ability to add alt text to images which require it throughout the site, while treating those which do not as decorative and applying the aria-hidden=true attribute in lieu of alt text.

Redundant links which are solely images without alt text also have aria-hidden applied. Links which have both text and images which do not require alt text will only have aria-hidden applied to the image leaving the link visible to screen readers.

Next steps are to run dubbot for any remaining issues.