### PR TITLE
TWM-535: Fix no method current_tags for nil.

### DIFF
--- a/spec/smoke/logger_spec.rb
+++ b/spec/smoke/logger_spec.rb
@@ -1,0 +1,10 @@
+# spec/smoke/logger_spec.rb
+require "rails_helper"
+
+RSpec.describe "Logger configuration" do
+  it "has a formatter that supports current_tags" do
+    expect(Rails.logger.formatter).to respond_to(:current_tags)
+    expect(Rails.logger.formatter.current_tags).to eq([])
+  end
+end
+

--- a/spec/smoke/logger_spec.rb
+++ b/spec/smoke/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # spec/smoke/logger_spec.rb
 require "rails_helper"
 
@@ -7,4 +9,3 @@ RSpec.describe "Logger configuration" do
     expect(Rails.logger.formatter.current_tags).to eq([])
   end
 end
-


### PR DESCRIPTION
This updates the logger configuraition so that instead wrapping each individual logger (stdout, file) with TaggedLogging and combining with a broadcaster, we first combine and then wrap with the tagger only only once.

The previous interation made the logger unlikely to respond to :tagged and therefore lead to weirdness.