### PR TITLE
Set version of application to CI_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ prod_deploy:
     - helm pull oci://$HARBOR/tulibraries/charts/tupress --version $HELM_VERSION_PROD --untar
     - |
       helm upgrade tupress oci://$HARBOR/tulibraries/charts/tupress \
-        --version $HELM_VERSION_PROD \
+        --version $CI_COMMIT_TAG \
         --history-max=5 --namespace=tupress-prod \
         --values tupress/values-prod.yaml \
         --set image.repository=$IMAGE:$VERSION \


### PR DESCRIPTION
helm --version sets the version of the app and in some versions of helm overrides the app image version.