### PR TITLE
Revert HELM_VERSION_PROD change and export VERSION=$CI_COMMIT_TAG.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,10 +116,11 @@ prod_deploy:
   only:
     - tags
   script:
+    - export VERSION=$CI_COMMIT_TAG
     - helm pull oci://$HARBOR/tulibraries/charts/tupress --version $HELM_VERSION_PROD --untar
     - |
       helm upgrade tupress oci://$HARBOR/tulibraries/charts/tupress \
-        --version $CI_COMMIT_TAG \
+        --version $HELM_VERSION_PROD \
         --history-max=5 --namespace=tupress-prod \
         --values tupress/values-prod.yaml \
         --set image.repository=$IMAGE:$VERSION \


### PR DESCRIPTION
I was wrong about there being two uses of --version in helm.

This change was tested successfully with a tul_cob deployment.