### PR TITLE
TWM-550-tu-press-inquiries-form-not-submitting

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -28,7 +28,7 @@ class FormsController < ApplicationController
       failure("html")
     elsif params[:form][:survey].present?
       failure("survey")
-    elsif params[:form][:add_to_mailing_list].present? && params[:form][:remove_from_mailing_list].present?
+    elsif params[:form][:add_to_mailing_list] == "1" && params[:form][:remove_from_mailing_list] == "1"
       failure("mailers")
     else
       @form.deliver ? success : failure("mail")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,7 +159,7 @@ en:
       errors:
         html: "HTML markup is not allowed in comments."
         survey: "Please check indicated fields for errors."
-        mailers: "Please check mailing options for errors."
+        mailers: "Please check mailing options for errors. Both adding and removing from the mailing list are not allowed in the same submission."
         smtp: "Unable to send form."
         turnstile: "Please complete the verification challenge and try again."
       attributes:

--- a/spec/requests/forms/inquiries_spec.rb
+++ b/spec/requests/forms/inquiries_spec.rb
@@ -10,5 +10,22 @@ RSpec.describe "Inquiries", type: :request do
     }
   end
 
+  it "does not show the mailing options error when both checkboxes are unchecked" do
+    ActionMailer::Base.deliveries = []
+
+    post("/forms", params: {
+      form: form_params.merge(
+        form_type:,
+        add_to_mailing_list: "0",
+        remove_from_mailing_list: "0"
+      )
+    })
+
+    expect(response).to redirect_to(root_path)
+    expect(flash[:notice]).to eq("Thank you for your message. We will contact you soon!")
+    expect(flash[:notice]).not_to eq(I18n.t("tupress.forms.errors.mailers"))
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+  end
+
   it_behaves_like "email form"
 end

--- a/spec/support/form_helper.rb
+++ b/spec/support/form_helper.rb
@@ -38,8 +38,8 @@ RSpec.shared_examples "email form" do
 
     it "fails on erroneous field options" do
       if form_type == "inquiries"
-        params[:form][:add_to_mailing_list] = true
-        params[:form][:remove_from_mailing_list] = true
+        params[:form][:add_to_mailing_list] = "1"
+        params[:form][:remove_from_mailing_list] = "1"
         post("/forms", params:)
         expect(response.body).to match /Please check mailing options for errors/
       end


### PR DESCRIPTION
Resolves error on submit where presence check was indicating both remove and add to mailing lists were selected when they were not. Also updates ambiguous error message displayed to user.