### PR TITLE
TWM-551-tu-press-form-errors-redirect-user-to-forms

### DIFF
--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -32,7 +32,11 @@
         </div>
       </div>
 
-      <%= simple_form_for @form, html: {class: "form-horizontal", enctype: "multipart" }, data: { turbo: "false"} do |f| %>
+      <%= simple_form_for @form,
+            url: form_path(type: @type, id: @book&.id || params[:id]),
+            method: :post,
+            html: {class: "form-horizontal", enctype: "multipart" },
+            data: { turbo: "false"} do |f| %>
       <%= f.input :form_type, as: :hidden, input_html: { value: "#{@type}" } %>
 
       <% if @type == "copy-request" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,7 @@ Rails.application.routes.draw do
   get "/open-access/labor-studies/:id"      => "oabooks#show", as: :labor_studies_book
   get "/open-access/north-broad-press/:id"  => "oabooks#show", as: :north_broad_book
 
-  get "forms", to: "forms#index", as: "forms_index"
+  post "forms/*type", to: "forms#create"
   get "forms/*type", to: "forms#new", as: "form"
 
   get "promotions", to: "special_offers#index"

--- a/spec/requests/forms/copy_request_spec.rb
+++ b/spec/requests/forms/copy_request_spec.rb
@@ -45,10 +45,11 @@ RSpec.describe "Request a Desk or Exam Copy", type: :request do
       it "rejects submission when verification fails" do
         allow(TurnstileService).to receive(:verify).and_return(false)
 
-        post("/forms", params: { form: form_params.merge(form_type: form_type), "cf-turnstile-response" => "bad-token" })
+        post(form_path(type: form_type), params: { form: form_params.merge(form_type: form_type), "cf-turnstile-response" => "bad-token" })
 
         expect(response).to have_http_status(:ok)
         expect(response).to render_template(:new)
+        expect(request.path).to eq(form_path(type: form_type))
         expect(response.body).to include("Please complete the verification challenge and try again.")
         expect(ActionMailer::Base.deliveries).to be_empty
       end
@@ -56,7 +57,7 @@ RSpec.describe "Request a Desk or Exam Copy", type: :request do
       it "submits normally when verification passes" do
         allow(TurnstileService).to receive(:verify).with(token: "good-token", remote_ip: anything).and_return(true)
 
-        post("/forms", params: { form: form_params.merge(form_type: form_type), "cf-turnstile-response" => "good-token" })
+        post(form_path(type: form_type), params: { form: form_params.merge(form_type: form_type), "cf-turnstile-response" => "good-token" })
 
         expect(response).to redirect_to(root_path)
         expect(ActionMailer::Base.deliveries.count).to eq(1)
@@ -76,7 +77,7 @@ RSpec.describe "Request a Desk or Exam Copy", type: :request do
       end
 
       it "accepts submission without a turnstile token" do
-        post("/forms", params: { form: form_params.merge(form_type: form_type) })
+        post(form_path(type: form_type), params: { form: form_params.merge(form_type: form_type) })
 
         expect(response).to redirect_to(root_path)
         expect(ActionMailer::Base.deliveries.count).to eq(1)

--- a/spec/requests/forms/inquiries_spec.rb
+++ b/spec/requests/forms/inquiries_spec.rb
@@ -10,10 +10,25 @@ RSpec.describe "Inquiries", type: :request do
     }
   end
 
+  it "re-renders on the form-specific path when mailing options are invalid" do
+    post(form_path(type: form_type), params: {
+      form: form_params.merge(
+        form_type:,
+        add_to_mailing_list: "1",
+        remove_from_mailing_list: "1"
+      )
+    })
+
+    expect(response).to have_http_status(:ok)
+    expect(response).to render_template(:new)
+    expect(request.path).to eq(form_path(type: form_type))
+    expect(response.body).to include("Please check mailing options for errors.")
+  end
+
   it "does not show the mailing options error when both checkboxes are unchecked" do
     ActionMailer::Base.deliveries = []
 
-    post("/forms", params: {
+    post(form_path(type: form_type), params: {
       form: form_params.merge(
         form_type:,
         add_to_mailing_list: "0",

--- a/spec/support/form_helper.rb
+++ b/spec/support/form_helper.rb
@@ -28,7 +28,7 @@ RSpec.shared_examples "email form" do
     end
 
     it "accepts information" do
-      post("/forms", params:)
+      post(form_path(type: form_type), params:)
       expect(the_email.subject).to eq(title)
       expect(the_email.from).to eq([Mail::Address.new(ActionMailer::Base.default_params[:from]).address])
       expect(the_email.reply_to).to eq([params[:form][:email]])
@@ -40,7 +40,7 @@ RSpec.shared_examples "email form" do
       if form_type == "inquiries"
         params[:form][:add_to_mailing_list] = "1"
         params[:form][:remove_from_mailing_list] = "1"
-        post("/forms", params:)
+        post(form_path(type: form_type), params:)
         expect(response.body).to match /Please check mailing options for errors/
       end
     end


### PR DESCRIPTION
This updates form submissions so validation and Turnstile errors stay on the form-specific URL instead of falling back to /forms. Each form now posts back to its own route, which preserves entered field values on render :new while avoiding the broken refresh behavior on errored submissions.