### PR TITLE
TWM-554-honeybadger-active-record-statement-invalid-in-webpages-search

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -23,9 +23,10 @@ class Author < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
+      escaped_q = Regexp.escape(q)
       Author.where(suppress: [nil, false])
-            .where("first_name ~* ?", "(^|\\W)#{q}(\\W|$)")
-            .or(Author.where(suppress: [nil, false]).where("last_name ~* ?", "(^|\\W)#{q}(\\W|$)"))
+            .where("first_name ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
+            .or(Author.where(suppress: [nil, false]).where("last_name ~* ?", "(^|\\W)#{escaped_q}(\\W|$)"))
             .sort_by { |a| [a.last_name, a.first_name] }
     end
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -139,11 +139,12 @@ class Book < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
+      escaped_q = Regexp.escape(q)
       Book.displayable
-          .where("title ~* ?", "(^|\\W)#{q}(\\W|$)")
-          .or(Book.where("sort_title ~* ?", "(^|\\W)#{q}(\\W|$)"))
-          .or(Book.where("subtitle ~* ?", "(^|\\W)#{q}(\\W|$)"))
-          .or(Book.where("author_byline ~* ?", "(^|\\W)#{q}(\\W|$)"))
+          .where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
+          .or(Book.where("sort_title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)"))
+          .or(Book.where("subtitle ~* ?", "(^|\\W)#{escaped_q}(\\W|$)"))
+          .or(Book.where("author_byline ~* ?", "(^|\\W)#{escaped_q}(\\W|$)"))
           .or(Book.where(isbn: q))
           .order(:sort_title)
     end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -8,7 +8,8 @@ class Conference < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
-      Conference.where("title ~* ?", "(^|\\W)#{q}(\\W|$)")
+      escaped_q = Regexp.escape(q)
+      Conference.where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,7 +15,8 @@ class Event < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
-      Event.where("title ~* ?", "(^|\\W)#{q}(\\W|$)")
+      escaped_q = Regexp.escape(q)
+      Event.where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
     end
   end
 end

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -10,8 +10,9 @@ class Faq < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
+      escaped_q = Regexp.escape(q)
       Faq.joins(:action_text_rich_text)
-         .where("action_text_rich_texts.body ~* ? OR title ~* ?", "(^|\\W)#{q}(\\W|$)", "(^|\\W)#{q}(\\W|$)")
+         .where("action_text_rich_texts.body ~* ? OR title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)", "(^|\\W)#{escaped_q}(\\W|$)")
     end
   end
 end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -7,7 +7,8 @@ class Journal < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
-      Journal.where("title ~* ?", "(^|\\W)#{q}(\\W|$)")
+      escaped_q = Regexp.escape(q)
+      Journal.where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
     end
   end
 end

--- a/app/models/oabook.rb
+++ b/app/models/oabook.rb
@@ -28,9 +28,10 @@ class Oabook < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
-      Oabook.where("title ~* ?", "(^|\\W)#{q}(\\W|$)")
-            .or(Oabook.where("subtitle ~* ?", "(^|\\W)#{q}(\\W|$)"))
-            .or(Oabook.where("author ~* ?", "(^|\\W)#{q}(\\W|$)"))
+      escaped_q = Regexp.escape(q)
+      Oabook.where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
+            .or(Oabook.where("subtitle ~* ?", "(^|\\W)#{escaped_q}(\\W|$)"))
+            .or(Oabook.where("author ~* ?", "(^|\\W)#{escaped_q}(\\W|$)"))
             .order(:title)
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -39,8 +39,9 @@ class Person < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
-      Person.where("title ~* ?", "(^|\\W)#{q}(\\W|$)")
-            .or(Person.where("position ~* ?", "(^|\\W)#{q}(\\W|$)"))
+      escaped_q = Regexp.escape(q)
+      Person.where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
+            .or(Person.where("position ~* ?", "(^|\\W)#{escaped_q}(\\W|$)"))
             .sort
     end
   end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -18,7 +18,8 @@ class Series < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
-      Series.where("title ~* ?", "(^|\\W)#{q}(\\W|$)")
+      escaped_q = Regexp.escape(q)
+      Series.where("title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)")
       .and(Series.where(unpublish: false))
       .sort
     end

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -12,8 +12,9 @@ class Webpage < ApplicationRecord
   def self.search(q)
     if q
       q = q.last.present? ? q : q[0...-1]
+      escaped_q = Regexp.escape(q)
       Webpage.joins(:action_text_rich_text)
-             .where("action_text_rich_texts.body ~* ? OR title ~* ?", "(^|\\W)#{q}(\\W|$)", "(^|\\W)#{q}(\\W|$)")
+             .where("action_text_rich_texts.body ~* ? OR title ~* ?", "(^|\\W)#{escaped_q}(\\W|$)", "(^|\\W)#{escaped_q}(\\W|$)")
     end
   end
 end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -7,4 +7,9 @@ RSpec.describe Author, type: :model do
     it { should validate_presence_of(:author_id) }
     it { should validate_presence_of(:last_name) }
   end
+
+  let(:search_query) { "Author (" }
+  let(:search_attributes) { { first_name: "Author (", last_name: "Tester" } }
+
+  it_behaves_like "regex-safe search"
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe Book, type: :model do
     expect(book.sort_titles).to eq "Way to Nirvana"
   end
 
+  let(:search_query) { "Book (" }
+  let(:search_attributes) { { title: "Book (Test)" } }
+
+  it_behaves_like "regex-safe search"
   it_behaves_like "detachable"
   it_behaves_like "attachable"
 end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -9,4 +9,9 @@ RSpec.describe Conference, type: :model do
     it { should validate_presence_of(:end_date) }
     it { should validate_presence_of(:location) }
   end
+
+  let(:search_query) { "Conference (" }
+  let(:search_attributes) { { title: "Conference (Test)" } }
+
+  it_behaves_like "regex-safe search"
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of(:start_date) }
     it { should validate_presence_of(:end_date) }
   end
+
+  let(:search_query) { "Event (" }
+  let(:search_attributes) { { title: "Event (Test)" } }
+
+  it_behaves_like "regex-safe search"
   it_behaves_like "detachable"
   it_behaves_like "attachable"
 end

--- a/spec/models/faq_spec.rb
+++ b/spec/models/faq_spec.rb
@@ -7,4 +7,9 @@ RSpec.describe Faq, type: :model do
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:answer) }
   end
+
+  let(:search_query) { "FAQ (" }
+  let(:search_attributes) { { title: "FAQ (Test)" } }
+
+  it_behaves_like "regex-safe search"
 end

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -7,4 +7,9 @@ RSpec.describe Journal, type: :model do
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:url) }
   end
+
+  let(:search_query) { "Journal (" }
+  let(:search_attributes) { { title: "Journal (Test)" } }
+
+  it_behaves_like "regex-safe search"
 end

--- a/spec/models/oabook_spec.rb
+++ b/spec/models/oabook_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Oabook, type: :model do
     it { should validate_presence_of(:collection) }
   end
 
+  let(:search_query) { "OA (" }
+  let(:search_attributes) { { title: "OA (Test)" } }
+
+  it_behaves_like "regex-safe search"
   it_behaves_like "attachable"
   it_behaves_like "detachable"
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Person, type: :model do
     it { should validate_presence_of(:department) }
   end
 
+  let(:search_query) { "Person (" }
+  let(:search_attributes) { { title: "Person (Test)" } }
+
+  it_behaves_like "regex-safe search"
   it_behaves_like "attachable"
   it_behaves_like "detachable"
 end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe Series, type: :model do
     it { should have_many(:books) }
   end
 
+  describe ".search" do
+    it "escapes regex metacharacters in the query" do
+      matching_series = create(:series, title: "Series (Test)", unpublish: false)
+      create(:series, title: "Other Series", unpublish: false)
+
+      expect { described_class.search("(Test)") }.not_to raise_error
+      expect(described_class.search("(Test)")).to include(matching_series)
+    end
+  end
+
+  let(:search_query) { "Series (" }
+  let(:search_attributes) { { title: "Series (Test)", unpublish: false } }
+
+  it_behaves_like "regex-safe search"
   it_behaves_like "attachable"
   it_behaves_like "detachable"
 end

--- a/spec/models/webpage_spec.rb
+++ b/spec/models/webpage_spec.rb
@@ -6,4 +6,9 @@ RSpec.describe Webpage, type: :model do
   describe "validations" do
     it { should validate_presence_of(:title) }
   end
+
+  let(:search_query) { "Webpage (" }
+  let(:search_attributes) { { title: "Webpage (Test)" } }
+
+  it_behaves_like "regex-safe search"
 end

--- a/spec/support/regex_safe_search_spec.rb
+++ b/spec/support/regex_safe_search_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+def regex_safe_search_factory
+  described_class.to_s.underscore.to_sym
+end
+
+RSpec.shared_examples "regex-safe search" do
+  it "does not raise for unbalanced parentheses in the query" do
+    create(regex_safe_search_factory, **search_attributes)
+
+    expect { described_class.search(search_query) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Malformed queries were breaking regex searches. This normalizes the query for regex before search, with shared example tests for affected models.